### PR TITLE
Defer initial local reflection capture across frames

### DIFF
--- a/src/local_reflection_probe.js
+++ b/src/local_reflection_probe.js
@@ -152,8 +152,9 @@ export function makeLocalReflectionProbe(T, renderer, scene, viewCamera, {size =
                 renderer.setRenderTarget(cube,0);
                 await renderer.compileAsync(scene,camera.children[0]);
             });
-            for(let i=0;i<6;i++) captureFace();
-            finishCapture();
+            // Keep the environment fallback until update() has captured all
+            // six faces. Compilation prepares the variant; presentation need
+            // not wait for the capture or its PMREM filtering.
         },
         update() {
             if (!environment || disposed) return;

--- a/tests/local-reflection-probe.test.mjs
+++ b/tests/local-reflection-probe.test.mjs
@@ -87,11 +87,19 @@ test('failed asynchronous probe warmup restores state and disposal releases each
     probe.update();assert.equal(renderer.draws.length,0);
 });
 
-test('probe warmup compiles the shared cube variant once but captures all six faces',async()=>{
+test('probe warmup compiles once and publishes only after six progressive updates',async()=>{
     const {probe,renderer}=fixture();let compilations=0;
     renderer.onCompile=()=>{compilations++};
     await probe.compileAsync();
     assert.equal(compilations,1);
+    assert.deepEqual(renderer.draws,[]);
+    assert.equal(probe.stats.captures,0);
+    for(let i=0;i<5;i++){
+        probe.update();
+        assert.equal(renderer.draws.length,i+1);
+        assert.equal(probe.stats.captures,0,'an incomplete cube must not be published');
+    }
+    probe.update();
     assert.deepEqual(renderer.draws,[0,1,2,3,4,5]);
     assert.equal(probe.stats.captures,1);
     assert.equal(probe.stats.faces,6);


### PR DESCRIPTION
Initial local reflections currently capture and prefilter all six cubemap faces before the world is shown. Compile the shared capture shader during startup, then use the existing one-face-per-frame update path. The environment fallback remains active until a complete probe is ready.

Validation: five probe tests pass, covering six-face publication, render-state restoration, capture failure/retry, and disposal. An isolated Chrome run on Apple M3 Max completed startup and the subsequent probe capture without page/GPU errors. This removes synchronous capture work from the startup gate; it does not eliminate shader compilation or the final prefilter cost.

Independent PR against main; also tested alongside the other performance changes. No native Metal or browser-specific device detection is introduced.
