### PR TITLE
Prefetch scene assets during terrain preparation

### DIFF
--- a/src/asset_preload.js
+++ b/src/asset_preload.js
@@ -1,0 +1,25 @@
+// Observe failures immediately: consumers await this batch later in boot.
+export function preloadTasks(tasks, concurrency = 4) {
+    if (!Number.isInteger(concurrency) || concurrency < 1) throw new Error('Invalid preload concurrency');
+    const result = new Array(tasks.length);
+    let next = 0, failed = false;
+    const worker = async () => {
+        while (!failed && next < tasks.length) {
+            const index = next++;
+            try { result[index] = await tasks[index](); }
+            catch (error) { failed = true; throw error; }
+        }
+    };
+    const pending = Promise.all(Array.from({length: Math.min(concurrency, tasks.length)}, worker))
+        .then(() => result);
+    pending.catch(() => {});
+    return pending;
+}
+
+export async function loadOptionalGLTF(loader, url, {request = fetch, baseURL = globalThis.location?.href} = {}) {
+    const response = await request(url);
+    if (response.status === 404) return null;
+    if (!response.ok) throw new Error(`Model ${url}: HTTP ${response.status}`);
+    const path = new URL('.', new URL(url, baseURL)).href;
+    return loader.parseAsync(await response.arrayBuffer(), path);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { fxaa as requiredFxaaFactory } from 'three/addons/tsl/display/FXAANode.js';
 import { makeAudioSystem } from './audio_system.js';
 import { fetchAssetBlob } from './asset_blob.js';
+import { preloadTasks, loadOptionalGLTF } from './asset_preload.js';
 import { FrameMetrics } from './frame_metrics.js';
 import { installShadowMaterialCache } from './shadow_material_cache.js';
 import { makeShadowRefreshPolicy } from './shadow_refresh.js';
@@ -933,6 +934,41 @@ const [
     { makeTerrain }, { makeTempleScene },
     { makeDesertDressing }, { makeVegetationScene },
 ] = await sceneModulesReady;
+// Fetch independent scene assets while terrain is prepared, with a bounded
+// number of requests/decodes. Construction still follows terrain -> scene.
+const architectureLoader = new GLTFLoader();
+const stoneRoot = './assets/pbr/sandstone_blocks_05/sandstone_blocks_05_';
+const mineralRoot = './assets/temple/materials/';
+const fixtureMetalRoot = './assets/temple/materials/ambientcg_metal010/Metal010_1K-JPG_';
+const perimeterRoot = './assets/eidoverse/perimeter/';
+const sceneAssetLoads = preloadTasks([
+    () => globalThis.loadImageTexture(stoneRoot + 'diff_1k.jpg', { srgb: true, mipmaps: true }),
+    () => globalThis.loadImageTexture(stoneRoot + 'nor_gl_1k.jpg', { mipmaps: true }),
+    () => globalThis.loadImageTexture(stoneRoot + 'rough_1k.jpg', { mipmaps: true }),
+    () => globalThis.loadImageTexture(stoneRoot + 'ao_1k.jpg', { mipmaps: true }),
+    () => globalThis.loadImageTexture(stoneRoot + 'disp_1k.jpg', { mipmaps: true }),
+    () => globalThis.loadImageTexture(mineralRoot + 'lapis_tiles_diff.png', { srgb: true, mipmaps: true }),
+    () => globalThis.loadImageTexture(mineralRoot + 'lapis_tiles_normal.png', { mipmaps: true }),
+    () => globalThis.loadImageTexture(mineralRoot + 'lapis_tiles_rough.png', { mipmaps: true }),
+    () => globalThis.loadImageTexture(mineralRoot + 'lapis_tiles_height.png', { mipmaps: true }),
+    () => globalThis.loadImageTexture(mineralRoot + 'carnelian_tiles_diff.png', { srgb: true, mipmaps: true }),
+    () => globalThis.loadImageTexture(mineralRoot + 'carnelian_tiles_normal.png', { mipmaps: true }),
+    () => globalThis.loadImageTexture(mineralRoot + 'carnelian_tiles_rough.png', { mipmaps: true }),
+    () => globalThis.loadImageTexture(mineralRoot + 'carnelian_tiles_height.png', { mipmaps: true }),
+    () => globalThis.loadImageTexture(fixtureMetalRoot + 'Color.jpg', { srgb: true, mipmaps: true }),
+    () => globalThis.loadImageTexture(fixtureMetalRoot + 'NormalGL.jpg', { mipmaps: true }),
+    () => globalThis.loadImageTexture(fixtureMetalRoot + 'Roughness.jpg', { mipmaps: true }),
+    () => globalThis.loadImageTexture(fixtureMetalRoot + 'Metalness.jpg', { mipmaps: true }),
+    () => globalThis.loadImageTexture('./assets/temple/decals/panel_fastener_decal-v1.png', { srgb: true, mipmaps: true }),
+    () => architectureLoader.loadAsync('./assets/temple/inanna_orb.glb'),
+    () => architectureLoader.loadAsync('./assets/temple/ziggurat_architecture.glb'),
+    () => architectureLoader.loadAsync(perimeterRoot + 'scifi_perimeter_wall_gate.glb'),
+    () => architectureLoader.loadAsync(perimeterRoot + 'scifi_perimeter_wall_middle_geometry.glb'),
+    () => architectureLoader.loadAsync(perimeterRoot + 'scifi_perimeter_wall_pillar_geometry.glb'),
+    () => architectureLoader.loadAsync(perimeterRoot + 'scifi_perimeter_watchtower_geometry.glb'),
+    () => new GLTFLoader().loadAsync('./assets/vegetation/saguaro_seed555.glb'),
+    () => loadOptionalGLTF(new GLTFLoader(), './assets/vegetation/joshuaTree_seed555.glb'),
+]);
 document.getElementById('boot').textContent = 'building the alluvial valley…';
 const terrain = await makeTerrain(THREE, renderer);
 scene.add(terrain);
@@ -940,42 +976,12 @@ globalThis._terrain = terrain;
 camera.position.y = terrain.heightAt(camera.position.x, camera.position.z) + 1.82;
 
 document.getElementById('boot').textContent = 'assembling the Eidoverse compound…';
-const architectureLoader = new GLTFLoader();
-const stoneRoot = './assets/pbr/sandstone_blocks_05/sandstone_blocks_05_';
-const mineralRoot = './assets/temple/materials/';
-const fixtureMetalRoot = './assets/temple/materials/ambientcg_metal010/Metal010_1K-JPG_';
-const perimeterRoot = './assets/eidoverse/perimeter/';
 const [templeAlbedo, templeNormal, templeRoughness, templeAo, templeDisplacement,
     lapisAlbedo, lapisNormal, lapisRoughness, lapisHeight,
     carnelianAlbedo, carnelianNormal, carnelianRoughness, carnelianHeight,
     fixtureMetalAlbedo, fixtureMetalNormal, fixtureMetalRoughness, fixtureMetalMetalness,
     panelFastenerDecal,
-    inannaGltf, zigguratGltf, gateGltf, wallGltf, pillarGltf, watchtowerGltf] = await Promise.all([
-    globalThis.loadImageTexture(stoneRoot + 'diff_1k.jpg', { srgb: true, mipmaps: true }),
-    globalThis.loadImageTexture(stoneRoot + 'nor_gl_1k.jpg', { mipmaps: true }),
-    globalThis.loadImageTexture(stoneRoot + 'rough_1k.jpg', { mipmaps: true }),
-    globalThis.loadImageTexture(stoneRoot + 'ao_1k.jpg', { mipmaps: true }),
-    globalThis.loadImageTexture(stoneRoot + 'disp_1k.jpg', { mipmaps: true }),
-    globalThis.loadImageTexture(mineralRoot + 'lapis_tiles_diff.png', { srgb: true, mipmaps: true }),
-    globalThis.loadImageTexture(mineralRoot + 'lapis_tiles_normal.png', { mipmaps: true }),
-    globalThis.loadImageTexture(mineralRoot + 'lapis_tiles_rough.png', { mipmaps: true }),
-    globalThis.loadImageTexture(mineralRoot + 'lapis_tiles_height.png', { mipmaps: true }),
-    globalThis.loadImageTexture(mineralRoot + 'carnelian_tiles_diff.png', { srgb: true, mipmaps: true }),
-    globalThis.loadImageTexture(mineralRoot + 'carnelian_tiles_normal.png', { mipmaps: true }),
-    globalThis.loadImageTexture(mineralRoot + 'carnelian_tiles_rough.png', { mipmaps: true }),
-    globalThis.loadImageTexture(mineralRoot + 'carnelian_tiles_height.png', { mipmaps: true }),
-    globalThis.loadImageTexture(fixtureMetalRoot + 'Color.jpg', { srgb: true, mipmaps: true }),
-    globalThis.loadImageTexture(fixtureMetalRoot + 'NormalGL.jpg', { mipmaps: true }),
-    globalThis.loadImageTexture(fixtureMetalRoot + 'Roughness.jpg', { mipmaps: true }),
-    globalThis.loadImageTexture(fixtureMetalRoot + 'Metalness.jpg', { mipmaps: true }),
-    globalThis.loadImageTexture('./assets/temple/decals/panel_fastener_decal-v1.png', { srgb: true, mipmaps: true }),
-    architectureLoader.loadAsync('./assets/temple/inanna_orb.glb'),
-    architectureLoader.loadAsync('./assets/temple/ziggurat_architecture.glb'),
-    architectureLoader.loadAsync(perimeterRoot + 'scifi_perimeter_wall_gate.glb'),
-    architectureLoader.loadAsync(perimeterRoot + 'scifi_perimeter_wall_middle_geometry.glb'),
-    architectureLoader.loadAsync(perimeterRoot + 'scifi_perimeter_wall_pillar_geometry.glb'),
-    architectureLoader.loadAsync(perimeterRoot + 'scifi_perimeter_watchtower_geometry.glb'),
-]);
+    inannaGltf, zigguratGltf, gateGltf, wallGltf, pillarGltf, watchtowerGltf, saguaroGltf, joshuaGltf] = await sceneAssetLoads;
 for (const texture of [
     templeAlbedo, templeNormal, templeRoughness, templeAo, templeDisplacement,
     lapisAlbedo, lapisNormal, lapisRoughness, lapisHeight,
@@ -1044,12 +1050,6 @@ scene.add(dressing.group);
 globalThis._desertDressing = dressing;
 
 document.getElementById('boot').textContent = 'planting SeedThree desert LODs…';
-const vegetationLoader = new GLTFLoader();
-const saguaroGltf = await vegetationLoader.loadAsync('./assets/vegetation/saguaro_seed555.glb');
-const joshuaUrl = './assets/vegetation/joshuaTree_seed555.glb';
-const joshuaGltf = (await fetch(joshuaUrl, { method: 'HEAD' })).ok
-    ? await vegetationLoader.loadAsync(joshuaUrl)
-    : null;
 const vegetation = await makeVegetationScene(THREE, {
     terrain,
     saguaroGltf,

--- a/tests/asset-preload.test.mjs
+++ b/tests/asset-preload.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {preloadTasks, loadOptionalGLTF} from '../src/asset_preload.js';
+
+test('preload bounds concurrency and preserves asset ordering', async () => {
+    let active = 0, peak = 0;
+    const values = await preloadTasks(Array.from({length: 12}, (_, i) => async () => {
+        peak = Math.max(peak, ++active);
+        await new Promise(resolve => setTimeout(resolve, (12 - i) % 3));
+        active--;
+        return i;
+    }), 3);
+    assert.equal(peak, 3);
+    assert.deepEqual(values, Array.from({length: 12}, (_, i) => i));
+});
+
+test('preload failures stop queued work and remain observable by a later consumer', async () => {
+    let queuedRan = false;
+    const pending = preloadTasks([
+        async () => {throw new Error('unavailable')},
+        async () => {queuedRan = true},
+    ], 1);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await assert.rejects(pending, /unavailable/);
+    assert.equal(queuedRan, false);
+});
+
+test('optional GLB uses one GET, keeps external resource base, and only tolerates missing files', async () => {
+    const calls = [], data = new ArrayBuffer(4);
+    const loader = {async parseAsync(bytes, path) {assert.equal(bytes, data); return path}};
+    const options = {baseURL: 'https://example.com/demo/', request: async url => {
+        calls.push(url); return {ok: true, status: 200, arrayBuffer: async () => data};
+    }};
+    assert.equal(await loadOptionalGLTF(loader, './assets/tree.glb', options), 'https://example.com/demo/assets/');
+    assert.deepEqual(calls, ['./assets/tree.glb']);
+    assert.equal(await loadOptionalGLTF(loader, './missing.glb', {...options, request: async () => ({status: 404})}), null);
+    await assert.rejects(loadOptionalGLTF(loader, './broken.glb', {...options, request: async () => ({status: 500})}), /HTTP 500/);
+});


### PR DESCRIPTION
Architecture and vegetation requests previously started after terrain and later construction stages finished. Start the independent asset batch alongside terrain preparation, with at most four tasks active in that batch and the original scene construction order preserved. Optional Joshua-tree loading now uses one GET instead of HEAD followed by GET; 404 remains optional, while other failures stay explicit.

Validation: three new tests cover concurrency bounds, result ordering, failure observation, and GLB resource-base handling. An isolated Apple M3 Max/Chrome startup completed without page/GPU errors. Terrain loading/transcoding retains its existing separate concurrency limits.

Independent PR against main; also tested alongside the other performance changes.
