### PR TITLE
Add a reduced GPU effects budget and fix half-resolution AO

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ corrections in [the September 10 report](REVIEW_2026-09-10.md).
 
 Controls are on-screen. Quality tiers in the panel; Balanced targets 60+ FPS.
 
+The separate **Reflections and shading** selector offers **Reduced GPU load**:
+half-resolution ambient occlusion with fewer samples and a shorter screen-space
+reflection range. Full detail remains the default. Sky quality and world detail
+are independent. Effect changes prepare their shaders behind the loading screen.
+Use `?effects-quality=performance` to open directly with the reduced effect budget.
+
 Cloud shadows work on scene PBR geometry without a terrain callback; see
 [the integration guide](docs/SKY_SYSTEM_INTEGRATION.md). Rain shelter, impacts,
 wetness and puddles use nearby surface geometry; see [engine/RAIN.md](engine/RAIN.md).

--- a/index.html
+++ b/index.html
@@ -106,6 +106,11 @@
     <option value="balanced" selected>Balanced — 60+ FPS target</option>
     <option value="performance">Performance — 120+ FPS target</option>
   </select>
+  <label for="effects-quality">Reflections and shading</label>
+  <select id="effects-quality">
+    <option value="balanced" selected>Full detail</option>
+    <option value="performance">Reduced GPU load</option>
+  </select>
   <label style="display:flex;align-items:center;gap:6px;margin-top:8px;color:#a8bdc9">
     <input id="ao" type="checkbox" checked style="width:auto"> WebGPU N8AO
   </label>

--- a/src/effects_quality.js
+++ b/src/effects_quality.js
@@ -1,0 +1,10 @@
+const profiles = Object.freeze({
+    balanced: Object.freeze({name: 'balanced', ssrDistance: 32, ssrQuality: 1, aoHalfRes: false, aoQuality: 'Medium'}),
+    // Keep one sample per projected pixel; sparse sampling produces gaps on
+    // curved reflective receivers. Reduce range and AO work instead.
+    performance: Object.freeze({name: 'performance', ssrDistance: 24, ssrQuality: 1, aoHalfRes: true, aoQuality: 'Low'}),
+});
+
+export function effectsQuality(name) {
+    return profiles[name] ?? profiles.balanced;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -31,7 +31,7 @@ import {
 // Reproducible scene links also let visual QA open the requested sky directly
 // instead of compiling Earth first and immediately rebuilding the whole scene.
 const launchSettings = new URLSearchParams(location.search);
-for (const id of ['skybox','cloud-type','weather','quality']) {
+for (const id of ['skybox','cloud-type','weather','quality','effects-quality']) {
     const control=document.getElementById(id),value=launchSettings.get(id);
     if(value&&[...control.options].some(option=>option.value===value))control.value=value;
 }
@@ -1482,9 +1482,9 @@ async function buildSkybox() {
         // overrides that merge intentional receiver weights into this contract.
         globalThis.eanpaStripMrt(scene);
         reflectionPipeline = makeReflectionPipeline(
-            // The sky selector must not degrade local reflections, N8AO, SSR,
-            // or bloom. Keep that scene pipeline at its authored setting.
-            THREE, renderer, scene, camera, active.sky, 'balanced',
+            // Scene effects have their own budget, independent of sky quality.
+            THREE, renderer, scene, camera, active.sky,
+            document.getElementById('effects-quality').value,
             requiredFxaaFactory, globalThis._reflectionEnv,
         );
         reflectionPipeline.setAOEnabled?.(aoPreference);
@@ -1633,6 +1633,7 @@ async function buildSkybox() {
 
 document.getElementById('skybox').addEventListener('change', buildSkybox);
 document.getElementById('quality').addEventListener('change', buildSkybox);
+document.getElementById('effects-quality').addEventListener('change', buildSkybox);
 cloudTypeControl.addEventListener('change', () => {
     const { cloudType } = syncSceneSelection();
     if (building) {

--- a/src/native_reflection_pipeline.js
+++ b/src/native_reflection_pipeline.js
@@ -1,3 +1,4 @@
+import { effectsQuality } from './effects_quality.js';
 import { N8AONode } from './vendor/n8ao/N8AONode.js';
 import { bloom } from 'three/addons/tsl/display/BloomNode.js';
 import { createConvexReceiverIds } from './reflection_receiver_id.js';
@@ -12,6 +13,7 @@ import { hasVisibleEmission } from './visible_emission.js';
 // Moving and skinned sources retain their reflections without stale self hits.
 // Fresnel, clearcoat, anisotropy and iridescence remain native Three lighting.
 export function makeNativeReflectionPipeline(T, renderer, scene, camera, sky, quality, fxaaFactory) {
+    const effects = effectsQuality(quality);
     const skyLayers = (sky.depthLayers ?? []).map(options => makeSkyGeometryLayer(T,renderer,scene,camera,options));
     const localProbe = makeLocalReflectionProbe(T,renderer,scene,camera);
     const receiverIds = createConvexReceiverIds();
@@ -45,7 +47,8 @@ export function makeNativeReflectionPipeline(T, renderer, scene, camera, sky, qu
     const previousNear = shared(camera.near), previousFar = shared(camera.far);
     const historyValid = shared(0);
     const historySize=shared(new T.Vector2(1,1));
-    const params = {maxDistance: shared(32), thickness: shared(0.15), quality: shared(1), coarseDepthGate: shared(1)};
+    const params = {maxDistance: shared(effects.ssrDistance), thickness: shared(0.15),
+        quality: shared(effects.ssrQuality), coarseDepthGate: shared(1)};
     const trace = makeScreenSpaceTrace({colorNode: sourceColor, depthNode: currentDepth,
         objectIdNode: T.sample(coord => currentIds.load(coord.mul(historySize).floor()).a),
         hitNormalNode:T.sample(coord=>currentIds.load(coord.mul(historySize).floor()).rgb.mul(2).sub(1)),
@@ -150,9 +153,9 @@ export function makeNativeReflectionPipeline(T, renderer, scene, camera, sky, qu
     const n8ao = new N8AONode({beautyNode:sceneColor, beautyTexture:scenePass.getTexture('output'),
         depthNode:scenePass.getTextureNode('depth'), depthTexture:scenePass.getTexture('depth'),
         normalNode:scenePass.getTextureNode('normal'), normalTexture:scenePass.getTexture('normal'), scene, camera});
-    Object.assign(n8ao.configuration, {halfRes:false, gammaCorrection:false, transparencyAware:false, accumulate:false});
+    Object.assign(n8ao.configuration, {halfRes:effects.aoHalfRes, gammaCorrection:false, transparencyAware:false, accumulate:false});
     n8ao.autoDetectTransparency = false;
-    n8ao.setQualityMode('Medium');
+    n8ao.setQualityMode(effects.aoQuality);
     const aoWeight = T.uniform(1), bloomWeight = T.uniform(1);
     const beauty = T.mix(sceneColor, n8ao.getTextureNode(), aoWeight.mul(scenePass.getTextureNode('metalrough').b));
     const glow = bloom(scenePass.getTextureNode('emissive'), .28, .42);
@@ -196,7 +199,8 @@ export function makeNativeReflectionPipeline(T, renderer, scene, camera, sky, qu
     return {supported:true, mode:'native-pbr-screen-space-radiance', pipeline, scenePass, history, trace, geometry, localProbe, skyLayers, registerObject, invalidateHistory,
         ssrImplementation:'current-geometry-motion-reprojected-radiance', ssrNode:params,
         ssrMaterialResponse:'native-three-base-clearcoat-anisotropy-iridescence-specular-ior',
-        nativeEnvironmentPbr:true, sceneColorAttachments:4, aoAvailable:true, aoQuality:'Medium',
+        nativeEnvironmentPbr:true, sceneColorAttachments:4, aoAvailable:true, aoQuality:effects.aoQuality,
+        effectsQuality:effects,
         bloomAvailable:true, get aoEnabled(){return aoEnabled}, get bloomEnabled(){return bloomEnabled},
         get bloomActive(){return bloomEnabled && emissionPresent},
         setAOEnabled(value){aoEnabled=!!value;aoWeight.value=aoEnabled?1:0;n8ao.enabled=aoEnabled;return aoEnabled;},

--- a/src/vendor/n8ao/N8AONode.js
+++ b/src/vendor/n8ao/N8AONode.js
@@ -608,13 +608,16 @@ export class N8AONode extends TempNode {
             });
             const chosenDepth = depthNode.sample(chosenUv).r.toVar();
             const chosenNormal = getNormalFromDepthWithResolution(chosenUv, depthTexture, projectionMatrixInverse, fullResolution).toVar();
-            return mrt({
-                [depthOutputName]: vec4(chosenDepth, 0, 0, 1),
-                [normalOutputName]: vec4(chosenNormal, 0),
-            });
+            return vec4(chosenNormal, chosenDepth);
         });
-        this.downsampleMaterial.fragmentNode =
-            this.applySharedContext(fragmentNode());
+        // NodeMaterial must see the output struct at the root. Wrapping MRT
+        // inside Fn/context made r184 declare a single color output while the
+        // body wrote output.m0/m1, producing invalid WGSL in half-res mode.
+        const sample = fragmentNode().toVar();
+        this.downsampleMaterial.fragmentNode = mrt({
+            [depthOutputName]: this.applySharedContext(vec4(sample.a, 0, 0, 1)),
+            [normalOutputName]: this.applySharedContext(vec4(sample.rgb, 0)),
+        });
         this.downsampleMaterial.needsUpdate = true;
     }
     configureAOPass() {

--- a/src/vendor/n8ao/VENDORED.md
+++ b/src/vendor/n8ao/VENDORED.md
@@ -2,4 +2,9 @@ Vendored from npm `n8ao-webgpu@0.1.0` (github.com/marioandf/n8ao-webgpu, CC0-1.0
 a three.js WebGPU port of N8AO by N8python — endorsed by the original author.
 The bare `three` / `three/tsl` / `three/webgpu` import specifiers resolve through
 the browser import map to this repository's vendored r184 build, guaranteeing one
-Three.js instance even though the package's peer range is ^0.182.0. No code changes.
+Three.js instance even though the package's peer range is ^0.182.0.
+
+Local compatibility patch: the half-resolution depth/normal downsample exposes
+its MRT at the fragment-node root. Wrapping the output struct in Fn/context
+caused r184 to declare a single color output and emit invalid WGSL member writes.
+The chosen depth/normal values and sampling algorithm are unchanged.


### PR DESCRIPTION
Add a separate “Reflections and shading” selector so users can reduce GPU work without changing sky or world detail. Full detail remains the default. Reduced GPU load uses half-resolution Low AO and a 24 m screen-space reflection range instead of 32 m; reflection sampling density remains unchanged to avoid the documented curved-receiver gaps.

Enabling half-resolution AO exposed an existing r184 compatibility error: its downsample shader wrapped an MRT output inside Fn/context, causing invalid WGSL member writes. Expose MRT at the fragment-node root while preserving the depth/normal calculation, and document the vendored patch.

Validation: isolated Apple M3 Max/Chrome startup with `?effects-quality=performance` completed without page/GPU errors after the fix; the rendered result was inspected. The combined regression suite passes. Effect changes still use the existing loading curtain and full rebuild, so this PR adds a runtime GPU budget rather than claiming instant switching or a cross-device FPS improvement.

Independent PR against main; no changes to native Metal APIs or adapter-name heuristics.
